### PR TITLE
[Feat] Naver Social 로그인 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,14 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	//oauth2
+	implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
+
+	//JWT
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/petplate/petplate/PetplateApplication.java
+++ b/src/main/java/com/petplate/petplate/PetplateApplication.java
@@ -2,8 +2,10 @@ package com.petplate.petplate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PetplateApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/petplate/petplate/auth/fortest/SocialLoginAndJwtTestController.java
+++ b/src/main/java/com/petplate/petplate/auth/fortest/SocialLoginAndJwtTestController.java
@@ -1,0 +1,34 @@
+package com.petplate.petplate.auth.fortest;
+
+import com.petplate.petplate.auth.interfaces.CurrentMemberLoginId;
+import com.petplate.petplate.common.response.BaseResponse;
+import com.petplate.petplate.common.response.error.ErrorCode;
+import com.petplate.petplate.common.response.error.exception.NotFoundException;
+import com.petplate.petplate.user.domain.entity.User;
+import com.petplate.petplate.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SocialLoginAndJwtTestController {
+
+    private final UserRepository userRepository;
+
+    @GetMapping("/test/login")
+    //@Operation(summary = "로그인 테스트 확인", description = "로그인 되어 있는지 판단합니다")
+    public ResponseEntity<BaseResponse<String>> checkLogin(@CurrentMemberLoginId String username) {
+
+        User findUser = getUserByUserId(username);
+
+        return ResponseEntity.ok(BaseResponse.createSuccess("로그인 성공을 축하드립니다 당신의 이름은 "+findUser.getName()));
+    }
+
+    private User getUserByUserId(final String username){
+        return userRepository.findByUsername(username).orElseThrow(()-> new NotFoundException(
+                ErrorCode.NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/petplate/petplate/auth/fortest/SocialLoginAndJwtTestController.java
+++ b/src/main/java/com/petplate/petplate/auth/fortest/SocialLoginAndJwtTestController.java
@@ -1,6 +1,6 @@
 package com.petplate.petplate.auth.fortest;
 
-import com.petplate.petplate.auth.interfaces.CurrentMemberLoginId;
+import com.petplate.petplate.auth.interfaces.CurrentUserUsername;
 import com.petplate.petplate.common.response.BaseResponse;
 import com.petplate.petplate.common.response.error.ErrorCode;
 import com.petplate.petplate.common.response.error.exception.NotFoundException;
@@ -19,7 +19,7 @@ public class SocialLoginAndJwtTestController {
 
     @GetMapping("/test/login")
     //@Operation(summary = "로그인 테스트 확인", description = "로그인 되어 있는지 판단합니다")
-    public ResponseEntity<BaseResponse<String>> checkLogin(@CurrentMemberLoginId String username) {
+    public ResponseEntity<BaseResponse<String>> checkLogin(@CurrentUserUsername String username) {
 
         User findUser = getUserByUserId(username);
 

--- a/src/main/java/com/petplate/petplate/auth/interfaces/CurrentMemberLoginId.java
+++ b/src/main/java/com/petplate/petplate/auth/interfaces/CurrentMemberLoginId.java
@@ -1,0 +1,14 @@
+package com.petplate.petplate.auth.interfaces;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this.getUsername()")
+public @interface CurrentMemberLoginId {
+
+}

--- a/src/main/java/com/petplate/petplate/auth/interfaces/CurrentUserUsername.java
+++ b/src/main/java/com/petplate/petplate/auth/interfaces/CurrentUserUsername.java
@@ -9,6 +9,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 @Target({ElementType.PARAMETER, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this.getUsername()")
-public @interface CurrentMemberLoginId {
+public @interface CurrentUserUsername {
 
 }

--- a/src/main/java/com/petplate/petplate/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/petplate/petplate/auth/jwt/JwtFilter.java
@@ -1,0 +1,47 @@
+package com.petplate.petplate.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final String AUTHORIZATION_KEY = "Authorization";
+    private final TokenProvider tokenProvider;
+    private final RedisTemplate<String,String> redisTemplate;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        String tokenValue = parseHeader(request);
+
+        if(StringUtils.hasText(tokenValue) && tokenProvider.validateToken(tokenValue)) {
+            String logOut=(String) redisTemplate.opsForValue().get(tokenValue);
+            if(ObjectUtils.isEmpty(logOut)){
+                Authentication authentication = tokenProvider.getAuthentication(tokenValue);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    public String parseHeader(HttpServletRequest request) {
+        String token = request.getHeader(AUTHORIZATION_KEY);
+
+        if(StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/petplate/petplate/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/petplate/petplate/auth/jwt/TokenProvider.java
@@ -1,0 +1,165 @@
+package com.petplate.petplate.auth.jwt;
+
+import com.petplate.petplate.auth.oauth.CustomOAuth2User;
+import com.petplate.petplate.auth.oauth.Dto.TokenDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class TokenProvider implements InitializingBean {
+    private final static String AUTHORIZATION_KEY = "auth";
+    private final Long validationTime;
+    private final Long refreshTokenValidationTime;
+    private final String secret;
+    private Key key;
+
+    public TokenProvider(@Value("${jwt.secret}") String secret,
+            @Value("${jwt.validationTime}") Long validationTime) {
+        this.secret = secret;
+        this.validationTime = validationTime * 1000;
+        this.refreshTokenValidationTime = validationTime * 2 * 1000;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] key_set = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(key_set);
+    }
+
+    // Authentication 객체를 통하여 토큰 생성
+    public TokenDto createToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities()
+                .stream().map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        String accessToken = Jwts.builder()
+                .setExpiration(new Date(now + validationTime))
+                .setSubject(authentication.getName())
+                .claim(AUTHORIZATION_KEY, authorities)
+                .signWith(this.key, SignatureAlgorithm.HS512)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + refreshTokenValidationTime))
+                .signWith(this.key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenValidationTime(validationTime)
+                .refreshTokenValidationTime(refreshTokenValidationTime)
+                .type("Bearer ")
+                .build();
+    }
+    public TokenDto createTokenByOAuth(CustomOAuth2User oAuth2User) {
+
+        String authorities = oAuth2User.getAuthorities()
+                .stream().map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+
+        String accessToken = Jwts.builder()
+                .setHeaderParam("typ","JWT")
+                .setExpiration(new Date(now + validationTime))//토큰 만료시간 payload 에 exp 의 형태로
+                .setSubject(oAuth2User.getUsername()) //토큰 sub (토큰 제목)
+                .claim(AUTHORIZATION_KEY, authorities)// auth 라는 key 로 authroities 즉 General or ADMIN 이 들어감
+                .signWith(this.key, SignatureAlgorithm.HS512)
+                .compact();
+
+
+        String refreshToken = Jwts.builder()
+                .setHeaderParam("type","JWT")
+                .setExpiration(new Date(now + refreshTokenValidationTime))
+                .signWith(this.key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenValidationTime(validationTime)
+                .refreshTokenValidationTime(refreshTokenValidationTime)
+                .type("Bearer ")
+                .build();
+    }
+
+    // 토큰을 통하여 Authentication 객체 생성
+    public Authentication getAuthentication(String token) {
+
+        Claims claims = parseData(token);
+
+        List<SimpleGrantedAuthority> authorities = Arrays
+                .stream(claims.get(AUTHORIZATION_KEY).toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        System.out.println(claims.getSubject());
+
+        User principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    // 토큰 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch(MalformedJwtException | SecurityException e) {
+            log.info("잘못된 형식의 토큰입니다.");
+        } catch(ExpiredJwtException e) {
+            log.info("만료된 토큰입니다.");
+        } catch(UnsupportedJwtException e) {
+            log.info("지원하지 않는 형식의 토큰입니다.");
+        } catch(IllegalArgumentException e) {
+            log.info("잘못된 토큰입니다.");
+        }
+        return false;
+    }
+
+    public Claims parseData(String token) {
+        try{
+            return Jwts.parserBuilder()
+                    .setSigningKey(this.key)
+                    .build().parseClaimsJws(token).getBody();
+        }
+        catch (ExpiredJwtException e){
+            return e.getClaims();
+        }
+    }
+    public Long getExpiration(String accessToken) {
+        // accessToken 남은 유효시간
+        Date expiration = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody().getExpiration();
+        // 현재 시간
+        Long now = new Date().getTime();
+        return (expiration.getTime() - now);
+    }
+
+}

--- a/src/main/java/com/petplate/petplate/auth/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/petplate/petplate/auth/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package com.petplate.petplate.auth.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petplate.petplate.common.response.BaseResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private static final String NOT_AUTHORIZED="권한이 존재하지 않습니다";
+    private final ObjectMapper objectMapper;
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(BaseResponse.createError(NOT_AUTHORIZED)));
+    }
+}

--- a/src/main/java/com/petplate/petplate/auth/jwt/handler/JwtAuthenticationEntryPointHandler.java
+++ b/src/main/java/com/petplate/petplate/auth/jwt/handler/JwtAuthenticationEntryPointHandler.java
@@ -1,0 +1,32 @@
+package com.petplate.petplate.auth.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petplate.petplate.common.response.BaseResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
+
+    private static final String NOT_AUTHENTICATED="인증에 실패하였습니다";
+    private final ObjectMapper objectMapper;
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(BaseResponse.createError(NOT_AUTHENTICATED)));
+
+    }
+}
+

--- a/src/main/java/com/petplate/petplate/auth/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/petplate/petplate/auth/oauth/CustomOAuth2User.java
@@ -1,0 +1,27 @@
+package com.petplate.petplate.auth.oauth;
+
+import com.petplate.petplate.user.domain.Role;
+import java.util.Collection;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private String username;
+    private Role role;
+
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+            Map<String, Object> attributes, String nameAttributeKey,
+            String username,Role role){
+
+        super(authorities,attributes,nameAttributeKey);
+        this.username = username;
+        this.role = role;
+
+    }
+}
+

--- a/src/main/java/com/petplate/petplate/auth/oauth/Dto/TokenDto.java
+++ b/src/main/java/com/petplate/petplate/auth/oauth/Dto/TokenDto.java
@@ -1,0 +1,18 @@
+package com.petplate.petplate.auth.oauth.Dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class TokenDto {
+    private String accessToken;
+    private String refreshToken;
+    private String type;
+    private Long accessTokenValidationTime;
+    private Long refreshTokenValidationTime;
+}

--- a/src/main/java/com/petplate/petplate/auth/oauth/OAuthAttributes.java
+++ b/src/main/java/com/petplate/petplate/auth/oauth/OAuthAttributes.java
@@ -1,0 +1,55 @@
+package com.petplate.petplate.auth.oauth;
+
+import com.petplate.petplate.auth.oauth.userinfo.NaverOAuth2UserInfo;
+import com.petplate.petplate.auth.oauth.userinfo.OAuth2UserInfo;
+import com.petplate.petplate.user.domain.Role;
+import com.petplate.petplate.user.domain.SocialType;
+import com.petplate.petplate.user.domain.entity.User;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuthAttributes {
+    private String nameAttributeKey;//OAuth2 로그인 진행 시 키가 되는 필드 값,PK와 같은 의미
+    private OAuth2UserInfo oauth2UserInfo;
+
+    @Builder
+    public OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oauth2UserInfo){
+        this.nameAttributeKey=nameAttributeKey;
+        this.oauth2UserInfo=oauth2UserInfo;
+    }
+    public static OAuthAttributes of(SocialType socialType,
+            String userNameAttributeName, Map<String, Object> attributes) {
+
+        if (socialType == SocialType.NAVER) {
+            return ofNaver(userNameAttributeName, attributes);
+        }
+
+        return null;
+    }
+
+    public static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new NaverOAuth2UserInfo(attributes))
+                .build();
+    }
+
+
+    public User toEntity(SocialType socialType, OAuth2UserInfo oauth2UserInfo) {
+
+        User user = User.builder()
+                .name(oauth2UserInfo.getName())
+                .role(Role.GENERAL)
+                .phoneNumber(oauth2UserInfo.getPhoneNumber())
+                .password(UUID.randomUUID()+"password")
+                .socialType(socialType)
+                .username(oauth2UserInfo.getEmail())
+                .build();
+
+        return user;
+    }
+}

--- a/src/main/java/com/petplate/petplate/auth/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/petplate/petplate/auth/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,58 @@
+package com.petplate.petplate.auth.oauth.handler;
+
+import com.petplate.petplate.auth.jwt.TokenProvider;
+import com.petplate.petplate.auth.oauth.CustomOAuth2User;
+import com.petplate.petplate.auth.oauth.Dto.TokenDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final TokenProvider tokenProvider;
+    private final RedisTemplate<String,String> redisTemplate;
+    private final static String authorization = "Authorization";
+    private final static String refreshToken = "refreshToken";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        try{
+
+            CustomOAuth2User oAuth2User=((CustomOAuth2User) authentication.getPrincipal());
+
+            TokenDto tokenDto=tokenProvider.createTokenByOAuth(oAuth2User);//OAuth2로 새로운 access,refreshToken 생성
+
+
+            redisTemplate.opsForValue().set(oAuth2User.getUsername(),tokenDto.getRefreshToken(),tokenDto.getRefreshTokenValidationTime(), TimeUnit.MILLISECONDS);
+            // Dto 객체를 JSON으로 변환하여 응답으로 전송
+            response.setHeader(authorization,tokenDto.getAccessToken());
+            response.setHeader(refreshToken,tokenDto.getRefreshToken());
+
+
+
+        }catch (Exception e){
+            throw e;
+        }
+
+
+    }
+
+    private String makeUrl(){
+        return "localhost:8080";
+    }
+
+
+}
+

--- a/src/main/java/com/petplate/petplate/auth/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/petplate/petplate/auth/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,85 @@
+package com.petplate.petplate.auth.oauth.service;
+
+import com.petplate.petplate.auth.oauth.CustomOAuth2User;
+import com.petplate.petplate.auth.oauth.OAuthAttributes;
+import com.petplate.petplate.user.domain.SocialType;
+import com.petplate.petplate.user.domain.entity.User;
+import com.petplate.petplate.user.repository.UserRepository;
+import java.util.Collections;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final UserRepository userRepository;
+
+    private static final String NAVER="naver";
+
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2UserService<OAuth2UserRequest,OAuth2User> delegate=new DefaultOAuth2UserService();
+        OAuth2User oAuth2User=delegate.loadUser(userRequest);
+
+        //1
+        String registrationId=userRequest.getClientRegistration().getRegistrationId();//Naver or google
+        SocialType socialType=getSocialType(registrationId);
+
+        //2
+        String userNameAttributeName=userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();//Naver :response Google: sub
+
+        //3
+        Map<String,Object> attributes=oAuth2User.getAttributes();
+
+
+
+        OAuthAttributes extractAttributes=OAuthAttributes.of(socialType,userNameAttributeName,attributes);
+
+        User createdMember=getUser(extractAttributes,socialType);
+
+        /*
+        String socialLoginAccessToken = userRequest.getAccessToken().getTokenValue();
+        System.out.println("socialLoginAccessToken"+socialLoginAccessToken);
+        */
+
+
+        return new CustomOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(createdMember.getRole().name())),
+                attributes,
+                extractAttributes.getNameAttributeKey(),
+                createdMember.getUsername(),createdMember.getRole()
+        );
+
+    }
+    //"naver"=>Enum
+    private SocialType getSocialType(String registrationId){
+
+        if(NAVER.equals(registrationId)){
+            return SocialType.NAVER;
+        }
+        return null;
+    }
+
+    //email과 socialtype으로 member
+    private User getUser(OAuthAttributes attributes,SocialType socialType){
+        User  findUser=userRepository.findBySocialTypeAndUsername(socialType,attributes.getOauth2UserInfo().getEmail()).orElseGet(()->saveUser(attributes,socialType));
+        return findUser;
+    }
+
+    // 소셜 로그인의 경우 비밀번호와 아이디는 저장되지 않는다. 따라서 아이디 와 비밀번호를 각각 소셜로그인 계정의 이메일과 UUID+"password" 로 임의로 설정한다.
+    private User saveUser(OAuthAttributes attributes,SocialType socialType){
+        User createdUser = attributes.toEntity(socialType,attributes.getOauth2UserInfo());
+        return userRepository.save(createdUser);
+    }
+}

--- a/src/main/java/com/petplate/petplate/auth/oauth/userinfo/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/petplate/petplate/auth/oauth/userinfo/NaverOAuth2UserInfo.java
@@ -1,0 +1,66 @@
+package com.petplate.petplate.auth.oauth.userinfo;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo{
+
+    private static final String userInfoName = "response";
+    private static final String ID="id";
+    private static final String NAME="name";
+    private static final String EMAIL="email";
+
+    private static final String MOBILE="mobile";
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+
+        Map<String, Object> response = (Map<String, Object>) attributes.get(userInfoName);
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get(ID);
+    }
+
+    @Override
+    public String getName() {
+
+        Map<String, Object> response = (Map<String, Object>) attributes.get(userInfoName);
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get(NAME);
+    }
+
+    @Override
+    public String getEmail() {
+
+        Map<String, Object> response = (Map<String, Object>) attributes.get(userInfoName);
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get(EMAIL);
+    }
+
+    @Override
+    public String getPhoneNumber(){
+
+        Map<String,Object> response = (Map<String, Object>) attributes.get(userInfoName);
+
+
+        if(response == null){
+            return null;
+        }
+
+        return (String) response.get(MOBILE);
+    }
+}
+

--- a/src/main/java/com/petplate/petplate/auth/oauth/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/petplate/petplate/auth/oauth/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,17 @@
+package com.petplate.petplate.auth.oauth.userinfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String,Object> attributes;
+
+    public OAuth2UserInfo(Map<String,Object> attributes){
+        this.attributes=attributes;
+    }
+
+    public abstract String getId();
+    public abstract String getPhoneNumber();
+    public abstract String getEmail();
+
+    public abstract String getName();
+}

--- a/src/main/java/com/petplate/petplate/common/config/SecurityConfig.java
+++ b/src/main/java/com/petplate/petplate/common/config/SecurityConfig.java
@@ -1,0 +1,65 @@
+package com.petplate.petplate.common.config;
+
+import com.petplate.petplate.auth.jwt.JwtFilter;
+import com.petplate.petplate.auth.jwt.TokenProvider;
+import com.petplate.petplate.auth.jwt.handler.JwtAccessDeniedHandler;
+import com.petplate.petplate.auth.jwt.handler.JwtAuthenticationEntryPointHandler;
+import com.petplate.petplate.auth.oauth.handler.OAuth2LoginSuccessHandler;
+import com.petplate.petplate.auth.oauth.service.CustomOAuth2UserService;
+import com.petplate.petplate.user.domain.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+@Configuration
+public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPointHandler jwtAuthenticationEntryPointHandler;
+
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessions -> sessions.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling((exception)->exception.authenticationEntryPoint(jwtAuthenticationEntryPointHandler))
+                .exceptionHandling((exception)->exception.accessDeniedHandler(jwtAccessDeniedHandler))
+                .authorizeHttpRequests((requests) ->
+                        requests
+                                .requestMatchers("/test/login").hasAuthority(Role.GENERAL.toString())
+                )
+                .oauth2Login(configure ->
+                        configure
+                                .userInfoEndpoint(
+                                        config -> config.userService(customOAuth2UserService))
+                                .successHandler(oAuth2LoginSuccessHandler)
+                );
+
+        return http.addFilterBefore(new JwtFilter(tokenProvider,redisTemplate), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+}

--- a/src/main/java/com/petplate/petplate/user/domain/SocialType.java
+++ b/src/main/java/com/petplate/petplate/user/domain/SocialType.java
@@ -1,0 +1,8 @@
+package com.petplate.petplate.user.domain;
+
+import com.petplate.petplate.auth.oauth.userinfo.NaverOAuth2UserInfo;
+import com.petplate.petplate.auth.oauth.userinfo.OAuth2UserInfo;
+
+public enum SocialType {
+    NAVER
+}

--- a/src/main/java/com/petplate/petplate/user/domain/entity/User.java
+++ b/src/main/java/com/petplate/petplate/user/domain/entity/User.java
@@ -52,6 +52,7 @@ public class User extends BaseEntity {
     private int level;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private SocialType socialType;
 
     @Builder

--- a/src/main/java/com/petplate/petplate/user/domain/entity/User.java
+++ b/src/main/java/com/petplate/petplate/user/domain/entity/User.java
@@ -2,6 +2,7 @@ package com.petplate.petplate.user.domain.entity;
 
 import com.petplate.petplate.common.Inheritance.BaseEntity;
 import com.petplate.petplate.user.domain.Role;
+import com.petplate.petplate.user.domain.SocialType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -38,7 +39,7 @@ public class User extends BaseEntity {
     @Column(length = 100,nullable = false)
     private String password;
 
-    @Column(length = 11,nullable = false)
+    @Column(length = 13,nullable = false)
     private String phoneNumber;
 
     @Column(nullable = false)
@@ -50,10 +51,13 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private int level;
 
+    @Column(nullable = false)
+    private SocialType socialType;
+
     @Builder
     public User(Role role, String name, String username, String password,
             String phoneNumber,
-            boolean isReceiveAd, boolean activated) {
+            boolean isReceiveAd, boolean activated,SocialType socialType) {
         this.role = role;
         this.name = name;
         this.username = username;
@@ -62,5 +66,6 @@ public class User extends BaseEntity {
         this.isReceiveAd = isReceiveAd;
         this.activated = activated;
         this.level = 1;
+        this.socialType = socialType;
     }
 }

--- a/src/main/java/com/petplate/petplate/user/repository/UserRepository.java
+++ b/src/main/java/com/petplate/petplate/user/repository/UserRepository.java
@@ -1,8 +1,17 @@
 package com.petplate.petplate.user.repository;
 
+import com.petplate.petplate.user.domain.SocialType;
 import com.petplate.petplate.user.domain.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User,Long> {
+
+    @Query("select u from User u where u.socialType=:socialType and u.username=:username")
+    Optional<User> findBySocialTypeAndUsername(@Param("socialType")SocialType socialType,@Param("username") String username);
+
+    Optional<User> findByUsername(String username);
 
 }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #21 

## 🏃‍ Task
- 작업사항 작성 📍 관련커밋: {커밋 ID}

- 네이버 소셜 로그인 
-  created at updated at 제대로 동작하게 Enable JPA auditing 추가
- 인증 및 인가 관련 테스트 


## 읽어봐야 할 점

- 실제 배포시에도 동작하는지 확인해야 해요!
- yml 파일 관련해서는 따로 공유할게요!
- 이미 강아지를 등록한 사용자의 경우 와 처음 로그인한 사용자의 경우 로그인한 후 첫 화면이 다른데 이를 redirect 기반으로 구현했어용 따라서
![image](https://github.com/CEOS-PAT-PLATE/BackEnd/assets/96781019/da8a46c3-68a9-44b8-8790-db8a385cb3cc)

아직 redirect 부분은 완성이 안되었습니당. (프론트와의 상의 필수 ) 

- 필요 정보가 우리는 현재 피그마 상 핸드폰 번호도 필요합니다. 미리 등록된 개발자의 계정 같은 경우는 괜찮은데 일반 사용자도 소셜 로그인을 진행하려면 우리는 사업자 인증을 받아야 핸드폰 번호를 받아올 수 있습니다 (다른 이메일이나 이름같은 부분은 인증화면만 필요)  따라서 데모데이 전까지 사업자 인증을 받는게 힘들면 이 부분을 빼야 할 것 같네영 (핸드폰 번호)  => 기획한테 문제점 공유후 수정할 부분 있으면 수정하겠습니당.

- 지금은 소셜 로그인으로만 되어 있지만 추후 확장성을 위해 username 과 password 를 지우지 않았고 

![image](https://github.com/CEOS-PAT-PLATE/BackEnd/assets/96781019/32337b7b-855e-4cf3-8c66-307a1b4638ee)

따라서 소셜 로그인 기반으로는 username과 password 에 무엇이 들어갈지 애매해서 

username 에는 이메일을 password 에는 UUID +"password" 를 넣었습니다. 

- 사용법은 나중에 공유드리겠습니다.

- 아직 완전히 다 소셜 로그인이 끝나지는 않았습니당! 

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?