### PR TITLE
Refactor: dailyRaw의 raw가 제거되어 null이 된 경우 rawId를 null로 반환

### DIFF
--- a/src/main/java/com/petplate/petplate/petdailymeal/dto/response/ReadDailyRawWithRawIdResponseDto.java
+++ b/src/main/java/com/petplate/petplate/petdailymeal/dto/response/ReadDailyRawWithRawIdResponseDto.java
@@ -29,7 +29,7 @@ public class ReadDailyRawWithRawIdResponseDto {
         ReadDailyRawWithRawIdResponseDto response
                 = new ReadDailyRawWithRawIdResponseDto();
 
-        response.rawId = dailyRaw.getRaw().getId();
+        response.rawId = dailyRaw.getRaw() != null ? dailyRaw.getRaw().getId() : null;
         response.dailyRawId = dailyRaw.getId();
         response.name = dailyRaw.getRaw().getName();
         response.description = dailyRaw.getRaw().getDescription();


### PR DESCRIPTION
## 🔥 Related Issue
- Close #이슈번호

## 🏃‍ Task
- ReadDailyRawWithRawIdResponseDto의 rawId를 반환시에 
- rawId = dailyRaw().getRaw().getId(); 
- 라는 부분이 존재함. 이때 dailyRaw().getRaw()가 null일 가능성이 존재함.
- 만일 Raw가 null일 경우 에러가 발생하므로 null인 경우에는 rawId가 null로 반환되도록 하고 아닌 경우에만 
- dailyRaw().getRaw().getId();로 rawId를 반환하도록 설정함.

## 📄 Reference
- None

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?