### PR TITLE
FIX: 영양소 중복 저장 문제 수정

### DIFF
--- a/src/main/java/com/petplate/petplate/common/response/error/ErrorCode.java
+++ b/src/main/java/com/petplate/petplate/common/response/error/ErrorCode.java
@@ -74,7 +74,11 @@ public enum ErrorCode {
     DATA_NOT_READY("데이터가 준비되지 않았습니다"),
     SOCIAL_ACCESS_ERROR("내부 엑세스 토큰으로부터 사용자 정보를 가져오지 못했습니다"),
     SOCIAL_REFRESH_TOKEN_ERROR("리프레시 토큰 기반으로 사용자 정보 연결 해제 실패"),
-    SOCIAL_UNLINK_FAIL("리프레시 토큰 기반 연동 해제 실패");
+    SOCIAL_UNLINK_FAIL("리프레시 토큰 기반 연동 해제 실패"),
+
+    SAME_DEFICIENT_NUTRIENT_EXISTS("부족 영양소 중복 저장"),
+    SAME_PROPER_NUTRIENT_EXISTS("적정 영양소 중복 저장"),
+    SAME_SUFFICIENT_NUTRIENT_EXISTS("과잉 영양소 중복 저장");
 
 
 

--- a/src/main/java/com/petplate/petplate/dailyMealNutrient/repository/ProperNutrientRepository.java
+++ b/src/main/java/com/petplate/petplate/dailyMealNutrient/repository/ProperNutrientRepository.java
@@ -11,4 +11,5 @@ public interface ProperNutrientRepository extends JpaRepository<ProperNutrient, 
     List<ProperNutrient> findByDailyMealId(Long dailyMealId);
     Optional<ProperNutrient> findByDailyMealIdAndName(Long dailyMealId, String name);
     boolean existsByDailyMealId(Long dailyMealId);
+    boolean existsByDailyMealIdAndName(Long dailyMealId, String name);
 }

--- a/src/main/java/com/petplate/petplate/dailyMealNutrient/repository/SufficientNutrientRepository.java
+++ b/src/main/java/com/petplate/petplate/dailyMealNutrient/repository/SufficientNutrientRepository.java
@@ -12,4 +12,6 @@ public interface SufficientNutrientRepository extends JpaRepository<SufficientNu
     List<SufficientNutrient> findByDailyMealId(Long dailyMealId);
     Optional<SufficientNutrient> findByDailyMealIdAndName(Long dailyMealId, String name);
     boolean existsByDailyMealId(Long dailyMealId);
+
+    boolean existsByDailyMealIdAndName(Long dailyMealId, String name);
 }

--- a/src/main/java/com/petplate/petplate/dailyMealNutrient/service/DeficientNutrientService.java
+++ b/src/main/java/com/petplate/petplate/dailyMealNutrient/service/DeficientNutrientService.java
@@ -91,15 +91,24 @@ public class DeficientNutrientService {
 
         List<ReadPetNutrientResponseDto> responses = new ArrayList<>();
         deficientNutrientRepository.findByDailyMealId(dailyMealId).forEach(deficientNutrient -> {
-            responses.add(
-                    ReadPetNutrientResponseDto.of(
-                            deficientNutrient.getName(),
-                            deficientNutrient.getUnit(),
-                            deficientNutrient.getDescription(),
-                            deficientNutrient.getAmount(),
-                            deficientNutrient.getProperAmount(),
-                            deficientNutrient.getMaximumAmount())
-            );
+
+            /**
+             * 중복 조회 로직
+             */
+            boolean isDuplicate = responses.stream()
+                    .anyMatch(response -> response.getName().equals(deficientNutrient.getName()));
+
+            if (!isDuplicate) {
+                responses.add(
+                        ReadPetNutrientResponseDto.of(
+                                deficientNutrient.getName(),
+                                deficientNutrient.getUnit(),
+                                deficientNutrient.getDescription(),
+                                deficientNutrient.getAmount(),
+                                deficientNutrient.getProperAmount(),
+                                deficientNutrient.getMaximumAmount())
+                );
+            }
         });
 
         return responses;

--- a/src/main/java/com/petplate/petplate/dailyMealNutrient/service/DeficientNutrientService.java
+++ b/src/main/java/com/petplate/petplate/dailyMealNutrient/service/DeficientNutrientService.java
@@ -3,6 +3,7 @@ package com.petplate.petplate.dailyMealNutrient.service;
 import com.petplate.petplate.common.EmbeddedType.StandardNutrient;
 import com.petplate.petplate.common.response.error.ErrorCode;
 import com.petplate.petplate.common.response.error.exception.BadRequestException;
+import com.petplate.petplate.common.response.error.exception.InternalServerErrorException;
 import com.petplate.petplate.common.response.error.exception.NotFoundException;
 import com.petplate.petplate.dailyMealNutrient.domain.entity.DeficientNutrient;
 import com.petplate.petplate.dailyMealNutrient.repository.DeficientNutrientRepository;
@@ -16,6 +17,7 @@ import com.petplate.petplate.petdailymeal.repository.DailyMealRepository;
 import com.petplate.petplate.utils.DailyMealUtil;
 import com.petplate.petplate.utils.PetUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,7 @@ import java.util.List;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class DeficientNutrientService {
     private final DailyMealRepository dailyMealRepository;
     private final DeficientNutrientRepository deficientNutrientRepository;
@@ -69,6 +72,11 @@ public class DeficientNutrientService {
                             .dailyMeal(dailyMealToday)
                             .build();
 
+                    // 알 수 없는 이유로 부족 영양소가 중복 저장되는 경우
+                    if (deficientNutrientRepository.existsByDailyMealIdAndName(dailyMealToday.getId(), nutrient.getName())) {
+                        log.error("중복 저장 부족영양소: " + nutrient.getName() + " dailyMealId: " + dailyMealToday.getId());
+                        throw new InternalServerErrorException(ErrorCode.SAME_DEFICIENT_NUTRIENT_EXISTS);
+                    }
                     deficientNutrientRepository.save(deficientNutrient);
                 });
 

--- a/src/main/java/com/petplate/petplate/dailyMealNutrient/service/ProperNutrientService.java
+++ b/src/main/java/com/petplate/petplate/dailyMealNutrient/service/ProperNutrientService.java
@@ -3,6 +3,7 @@ package com.petplate.petplate.dailyMealNutrient.service;
 import com.petplate.petplate.common.EmbeddedType.StandardNutrient;
 import com.petplate.petplate.common.response.error.ErrorCode;
 import com.petplate.petplate.common.response.error.exception.BadRequestException;
+import com.petplate.petplate.common.response.error.exception.InternalServerErrorException;
 import com.petplate.petplate.common.response.error.exception.NotFoundException;
 import com.petplate.petplate.dailyMealNutrient.domain.entity.ProperNutrient;
 import com.petplate.petplate.dailyMealNutrient.repository.ProperNutrientRepository;
@@ -16,6 +17,7 @@ import com.petplate.petplate.petdailymeal.repository.DailyMealRepository;
 import com.petplate.petplate.utils.DailyMealUtil;
 import com.petplate.petplate.utils.PetUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,11 +30,12 @@ import java.util.List;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class ProperNutrientService {
     private final DailyMealRepository dailyMealRepository;
     private final ProperNutrientRepository properNutrientRepository;
     private final PetRepository petRepository;
-    
+
     @Transactional
     public void createProperNutrientsToday(String username, Long petId) {
         Pet pet = PetUtil.validUserAndFindPet(username, petId, petRepository);
@@ -68,6 +71,12 @@ public class ProperNutrientService {
                             .maximumAmount(maximumAmount)
                             .dailyMeal(dailyMealToday)
                             .build();
+
+                    // 알 수 없는 이유로 적정 영양소가 중복 저장되는 경우
+                    if (properNutrientRepository.existsByDailyMealIdAndName(dailyMealToday.getId(), nutrient.getName())) {
+                        log.error("중복 저장 적정영양소: " + nutrient.getName() + " dailyMealId: " + dailyMealToday.getId());
+                        throw new InternalServerErrorException(ErrorCode.SAME_PROPER_NUTRIENT_EXISTS);
+                    }
 
                     properNutrientRepository.save(properNutrient);
                 });

--- a/src/main/java/com/petplate/petplate/dailyMealNutrient/service/ProperNutrientService.java
+++ b/src/main/java/com/petplate/petplate/dailyMealNutrient/service/ProperNutrientService.java
@@ -92,15 +92,24 @@ public class ProperNutrientService {
 
         List<ReadPetNutrientResponseDto> responses = new ArrayList<>();
         properNutrientRepository.findByDailyMealId(dailyMealId).forEach(properNutrient -> {
-            responses.add(
-                    ReadPetNutrientResponseDto.of(
-                            properNutrient.getName(),
-                            properNutrient.getUnit(),
-                            properNutrient.getDescription(),
-                            properNutrient.getAmount(),
-                            properNutrient.getProperAmount(),
-                            properNutrient.getMaximumAmount())
-            );
+
+            /**
+             * 중복 조회 로직
+             */
+            boolean isDuplicate = responses.stream()
+                    .anyMatch(response -> response.getName().equals(properNutrient.getName()));
+
+            if (!isDuplicate) {
+                responses.add(
+                        ReadPetNutrientResponseDto.of(
+                                properNutrient.getName(),
+                                properNutrient.getUnit(),
+                                properNutrient.getDescription(),
+                                properNutrient.getAmount(),
+                                properNutrient.getProperAmount(),
+                                properNutrient.getMaximumAmount())
+                );
+            }
         });
 
         return responses;

--- a/src/main/java/com/petplate/petplate/dailyMealNutrient/service/SufficientNutrientService.java
+++ b/src/main/java/com/petplate/petplate/dailyMealNutrient/service/SufficientNutrientService.java
@@ -3,6 +3,7 @@ package com.petplate.petplate.dailyMealNutrient.service;
 import com.petplate.petplate.common.EmbeddedType.StandardNutrient;
 import com.petplate.petplate.common.response.error.ErrorCode;
 import com.petplate.petplate.common.response.error.exception.BadRequestException;
+import com.petplate.petplate.common.response.error.exception.InternalServerErrorException;
 import com.petplate.petplate.common.response.error.exception.NotFoundException;
 import com.petplate.petplate.dailyMealNutrient.domain.entity.SufficientNutrient;
 import com.petplate.petplate.dailyMealNutrient.repository.SufficientNutrientRepository;
@@ -16,6 +17,7 @@ import com.petplate.petplate.petdailymeal.repository.DailyMealRepository;
 import com.petplate.petplate.utils.DailyMealUtil;
 import com.petplate.petplate.utils.PetUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,7 @@ import java.util.List;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class SufficientNutrientService {
     private final DailyMealRepository dailyMealRepository;
     private final SufficientNutrientRepository sufficientNutrientRepository;
@@ -68,6 +71,12 @@ public class SufficientNutrientService {
                             .maximumAmount(maximumAmount)
                             .dailyMeal(dailyMealToday)
                             .build();
+
+                    // 알 수 없는 이유로 과잉 영양소가 중복 저장되는 경우
+                    if (sufficientNutrientRepository.existsByDailyMealIdAndName(dailyMealToday.getId(), nutrient.getName())) {
+                        log.error("중복 저장 과잉영양소: " + nutrient.getName() + " dailyMealId: " + dailyMealToday.getId());
+                        throw new InternalServerErrorException(ErrorCode.SAME_SUFFICIENT_NUTRIENT_EXISTS);
+                    }
 
                     sufficientNutrientRepository.save(sufficientNutrient);
                 });

--- a/src/main/java/com/petplate/petplate/dailyMealNutrient/service/SufficientNutrientService.java
+++ b/src/main/java/com/petplate/petplate/dailyMealNutrient/service/SufficientNutrientService.java
@@ -91,15 +91,24 @@ public class SufficientNutrientService {
 
         List<ReadPetNutrientResponseDto> responses = new ArrayList<>();
         sufficientNutrientRepository.findByDailyMealId(dailyMealId).forEach(sufficientNutrient -> {
-            responses.add(
-                    ReadPetNutrientResponseDto.of(
-                            sufficientNutrient.getName(),
-                            sufficientNutrient.getUnit(),
-                            sufficientNutrient.getDescription(),
-                            sufficientNutrient.getAmount(),
-                            sufficientNutrient.getProperAmount(),
-                            sufficientNutrient.getMaximumAmount())
-            );
+
+            /**
+             * 중복 조회 로직
+             */
+            boolean isDuplicate = responses.stream()
+                    .anyMatch(response -> response.getName().equals(sufficientNutrient.getName()));
+
+            if (!isDuplicate) {
+                responses.add(
+                        ReadPetNutrientResponseDto.of(
+                                sufficientNutrient.getName(),
+                                sufficientNutrient.getUnit(),
+                                sufficientNutrient.getDescription(),
+                                sufficientNutrient.getAmount(),
+                                sufficientNutrient.getProperAmount(),
+                                sufficientNutrient.getMaximumAmount())
+                );
+            }
         });
 
         return responses;

--- a/src/main/java/com/petplate/petplate/petdailymeal/controller/DailyMealController.java
+++ b/src/main/java/com/petplate/petplate/petdailymeal/controller/DailyMealController.java
@@ -36,6 +36,7 @@ public class DailyMealController {
     private static final String CREATED = "201";
     private static final String BAD_REQUEST = "400";
     private static final String NOT_FOUND = "404";
+    private static final String INTERNAL_SERVER_ERROR = "500";
 
     @Operation(summary = "날짜로 반려견의 식사 내역 조회", description = "식사 내역을 조회합니다.(날짜 미입력시 모든 식사내역 반환) 반환 값으로는 식사의 PK, 식사 날짜 정보가 포함됩니다.")
     @ApiResponses(value = {
@@ -155,6 +156,7 @@ public class DailyMealController {
             @ApiResponse(responseCode = CREATED, description = "영양 분석 성공(오늘 식사에 대한 부족/과잉/적정 영양소 내용을 성공적 저장)"),
             @ApiResponse(responseCode = BAD_REQUEST, description = "조회하려는 반려견이 본인의 반려견이 아닌 경우, 이미 오늘 영양소 분석을 진행 한 경우"),
             @ApiResponse(responseCode = NOT_FOUND, description = "잘못된 petId, 오늘 식사내역이 존재하지 않는 경우"),
+            @ApiResponse(responseCode = INTERNAL_SERVER_ERROR, description = "알 수 없는 이유로 과잉, 적정, 부족 영양소가 중복으로 저장된 경우"),
     })
     @PostMapping("/pet/{petId}/dailyMeals/nutrients")
     public ResponseEntity<BaseResponse> createDailyMealNutrients(@CurrentUserUsername String username, @PathVariable("petId") Long petId) {


### PR DESCRIPTION
## 🔥 Related Issue
- Close #142 

## 🏃‍ Task
- 영양소 테이블이 중복 저장시 500 에러가 발생하도록 구현
- 혹시라도 중복된 칼럼이 존재하더라도 dto는 하나만 반환

## 📄 Reference
- None

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?