### PR TITLE
Refactor: 연관관계 버그 수정, 섭취 음식 제거 로직 수정

### DIFF
--- a/src/main/java/com/petplate/petplate/medicalcondition/domain/entity/RawProhibitedByAllergy.java
+++ b/src/main/java/com/petplate/petplate/medicalcondition/domain/entity/RawProhibitedByAllergy.java
@@ -25,11 +25,11 @@ public class RawProhibitedByAllergy {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "allergy_id",nullable = false)
+    @JoinColumn(name = "allergy_id")
     private Allergy allergy;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "raw_id",nullable = false)
+    @JoinColumn(name = "raw_id")
     private Raw raw;
 
     @Builder

--- a/src/main/java/com/petplate/petplate/medicalcondition/domain/entity/RawProhibitedByDisease.java
+++ b/src/main/java/com/petplate/petplate/medicalcondition/domain/entity/RawProhibitedByDisease.java
@@ -25,11 +25,11 @@ public class RawProhibitedByDisease {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "disease_id",nullable = false)
+    @JoinColumn(name = "disease_id")
     private Disease disease;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "raw_id",nullable = false)
+    @JoinColumn(name = "raw_id")
     private Raw raw;
 
     @Builder
@@ -37,7 +37,6 @@ public class RawProhibitedByDisease {
         this.disease = disease;
         this.raw = raw;
     }
-
 
 
 }

--- a/src/main/java/com/petplate/petplate/petdailymeal/dto/response/ReadDailyBookMarkedFeedResponseDto.java
+++ b/src/main/java/com/petplate/petplate/petdailymeal/dto/response/ReadDailyBookMarkedFeedResponseDto.java
@@ -10,16 +10,16 @@ import lombok.*;
 public class ReadDailyBookMarkedFeedResponseDto {
     private Long dailyBookMarkedFeedId;
     private String name;
-    private double serving;
-    private double kcal;
-    private double carbonHydrate;
-    private double protein;
-    private double fat;
-    private double calcium;
-    private double phosphorus;
-    private double vitaminA;
-    private double vitaminD;
-    private double vitaminE;
+    private Double serving;
+    private Double kcal;
+    private Double carbonHydrate;
+    private Double protein;
+    private Double fat;
+    private Double calcium;
+    private Double phosphorus;
+    private Double vitaminA;
+    private Double vitaminD;
+    private Double vitaminE;
 
     public static ReadDailyBookMarkedFeedResponseDto from(DailyBookMarkedFeed dailybookMarkedFeed) {
         ReadDailyBookMarkedFeedResponseDto response

--- a/src/main/java/com/petplate/petplate/petdailymeal/dto/response/ReadDailyBookMarkedPackagedSnackResponseDto.java
+++ b/src/main/java/com/petplate/petplate/petdailymeal/dto/response/ReadDailyBookMarkedPackagedSnackResponseDto.java
@@ -10,16 +10,16 @@ import lombok.*;
 public class ReadDailyBookMarkedPackagedSnackResponseDto {
     private Long dailyBookMarkedPackagedSnackId;
     private String name;
-    private double serving;
-    private double kcal;
-    private double carbonHydrate;
-    private double protein;
-    private double fat;
-    private double calcium;
-    private double phosphorus;
-    private double vitaminA;
-    private double vitaminD;
-    private double vitaminE;
+    private Double serving;
+    private Double kcal;
+    private Double carbonHydrate;
+    private Double protein;
+    private Double fat;
+    private Double calcium;
+    private Double phosphorus;
+    private Double vitaminA;
+    private Double vitaminD;
+    private Double vitaminE;
 
     public static ReadDailyBookMarkedPackagedSnackResponseDto from(DailyBookMarkedPackagedSnack dailyBookMarkedPackagedSnack) {
         ReadDailyBookMarkedPackagedSnackResponseDto response

--- a/src/main/java/com/petplate/petplate/petdailymeal/dto/response/ReadDailyBookMarkedRawResponseDto.java
+++ b/src/main/java/com/petplate/petplate/petdailymeal/dto/response/ReadDailyBookMarkedRawResponseDto.java
@@ -13,16 +13,16 @@ public class ReadDailyBookMarkedRawResponseDto {
     private Long dailyBookMarkedRawId;
     private String name;
     private String description;
-    private double serving;
-    private double kcal;
-    private double carbonHydrate;
-    private double protein;
-    private double fat;
-    private double calcium;
-    private double phosphorus;
-    private double vitaminA;
-    private double vitaminD;
-    private double vitaminE;
+    private Double serving;
+    private Double kcal;
+    private Double carbonHydrate;
+    private Double protein;
+    private Double fat;
+    private Double calcium;
+    private Double phosphorus;
+    private Double vitaminA;
+    private Double vitaminD;
+    private Double vitaminE;
 
     public static ReadDailyBookMarkedRawResponseDto from(DailyBookMarkedRaw dailybookMarkedRaw) {
         ReadDailyBookMarkedRawResponseDto response


### PR DESCRIPTION
## 🔥 Related Issue
- Close #144 
## 🏃‍ Task
- 기존 nullable=false를 연관관계 제거를 위해 nullable = true 변경
- dto 매개변수 타입을 double에서 Double로 변경. 반환값 중 기존에는 반환될 값이 없는 경우 0이 반환되었지만 Double로 설정하여 null이 반환되도록 수정함.
- 섭취한 즐겨찾기 음식제거 로직 수정. 예를 들어 dailyBookMarkedRaw의 BookMarkedRaw가 제거되어 null이 된 경우, 해당 dailyBookMarkedRaw는 제거하지 못하게 함. 그 경우에는 log를 띄우도록 함

## 📄 Reference
- None

## ✅ Check List
- [ ]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [ ]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ]  팀의 코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [ ]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?